### PR TITLE
[diskusage] Fix apkd size calls for AAS. JB#58028

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ moc_*
 *.so
 *.so.*
 *.qm
+filemanager.pc
+fileoperationsadaptor.*
+fileoperationsproxy.*
+fileoperationsd
+ut_diskusage
+tests.xml

--- a/src/plugin/diskusage.h
+++ b/src/plugin/diskusage.h
@@ -38,8 +38,11 @@
 #include <QJSValue>
 #include <QScopedPointer>
 #include <QDir>
+#include <QLoggingCategory>
 
 #include <filemanagerglobal.h>
+
+Q_DECLARE_LOGGING_CATEGORY(diskUsage)
 
 class DiskUsagePrivate;
 

--- a/src/plugin/diskusage_p.h
+++ b/src/plugin/diskusage_p.h
@@ -59,13 +59,17 @@ signals:
 
 private:
     QVariantMap calculate(QStringList paths);
-    quint64 calculateSize(QString directory, QString *expandedPath, bool androidHomeExists);
+    quint64 calculateSize(QString directory, QString *expandedPath = nullptr);
     quint64 calculateRpmSize(const QString &glob);
     quint64 calculateApkdSize(const QString &rest);
     int counting(const QString &path, DiskUsage::Filter filter, bool recursive);
 
     bool m_quit;
     bool m_stopCounting;
+    bool m_apkd_data_queried = false;
+    qulonglong m_apkd_app = 0;
+    qulonglong m_apkd_data = 0;
+    qulonglong m_apkd_run = 0;
 
     friend class Ut_DiskUsage;
 };

--- a/src/plugin/fileworker.cpp
+++ b/src/plugin/fileworker.cpp
@@ -32,6 +32,7 @@
 
 #include "fileworker.h"
 #include "fileoperations.h"
+#include "diskusage.h"
 
 #include <QQmlInfo>
 #include <QCoreApplication>
@@ -149,7 +150,7 @@ bool FileWorker::mkdir(QString path, QString name, bool nonprivileged)
     QDBusPendingReply<uint> reply = m_proxy.Mkdir(name, path);
     reply.waitForFinished();
     if (reply.isError()) {
-        qWarning() << "Error waiting for file operation reply";
+        qCWarning(diskUsage) << "Error waiting for file operation reply";
         return false;
     }
 
@@ -165,7 +166,7 @@ bool FileWorker::rename(QString oldPath, QString newPath, bool nonprivileged)
     QDBusPendingReply<uint> reply = m_proxy.Rename(oldPath, newPath);
     reply.waitForFinished();
     if (reply.isError()) {
-        qWarning() << "Error waiting for file operation reply";
+        qCWarning(diskUsage) << "Error waiting for file operation reply";
         return false;
     }
 
@@ -181,7 +182,7 @@ bool FileWorker::setPermissions(QString path, QFileDevice::Permissions p, bool n
     QDBusPendingReply<uint> reply = m_proxy.SetPermissions(path, static_cast<unsigned>(p));
     reply.waitForFinished();
     if (reply.isError()) {
-        qWarning() << "Error waiting for file operation reply";
+        qCWarning(diskUsage) << "Error waiting for file operation reply";
         return false;
     }
 
@@ -223,7 +224,7 @@ void FileWorker::startOperation(bool nonprivileged)
     }
     
     if (reply.isError()) {
-        qWarning() << "Uanble to invoke remote file operation:" << reply.error().message();
+        qCWarning(diskUsage) << "Uanble to invoke remote file operation:" << reply.error().message();
     } else {
         if (reply.isFinished()) {
             m_operation = reply.value();
@@ -255,7 +256,7 @@ void FileWorker::fileOperationFailed(unsigned id, const QStringList &paths, unsi
             emit error(result, fileName);
         }
     } else if (m_operation != 0) {
-        qWarning() << Q_FUNC_INFO << "Unknown operation:" << id << "!=" << m_operation;
+        qCWarning(diskUsage) << Q_FUNC_INFO << "Unknown operation:" << id << "!=" << m_operation;
     }
 }
 
@@ -267,7 +268,7 @@ void FileWorker::fileOperationSucceeded(unsigned id, const QStringList &paths)
                 emit fileDeleted(path);
         }
     } else if (m_operation != 0) {
-        qWarning() << Q_FUNC_INFO << "Unknown operation:" << id << "!=" << m_operation;
+        qCWarning(diskUsage) << Q_FUNC_INFO << "Unknown operation:" << id << "!=" << m_operation;
     }
 }
 
@@ -278,7 +279,7 @@ void FileWorker::operationFinished(unsigned id)
 
         emit done();
     } else if (m_operation != 0) {
-        qWarning() << Q_FUNC_INFO << "Unknown operation:" << id << "!=" << m_operation;
+        qCWarning(diskUsage) << Q_FUNC_INFO << "Unknown operation:" << id << "!=" << m_operation;
     }
 }
 

--- a/tests/ut_diskusage/ut_diskusage.cpp
+++ b/tests/ut_diskusage/ut_diskusage.cpp
@@ -52,7 +52,7 @@ static QVariantMap g_mocked_apkd_size;
 
 
 /* Mocked implementations of size calculation functions */
-quint64 DiskUsageWorker::calculateSize(QString directory, QString *expandedPath, bool)
+quint64 DiskUsageWorker::calculateSize(QString directory, QString *expandedPath)
 {
     if (expandedPath) {
         *expandedPath = directory;


### PR DESCRIPTION
getAndroidAppDataUsage has been reimplemented to query app and data sizes
from within the container, so both of those come from apkd for AAS.

The old android home distinction is no longer relevant after support for the Jolla1 was removed, so that's dropped.