### PR TITLE
[nemo-qml-plugin-filemanager] Fix unit test failure. JB#61527

### DIFF
--- a/tests/auto/tst_filemodel.qml
+++ b/tests/auto/tst_filemodel.qml
@@ -69,7 +69,7 @@ Item {
             {fileName: "c", baseName: "c", extension: "", mimeType: "text/plain", size: 4, isDir: false},
             {fileName: "subfolder", baseName: "subfolder", extension: "", mimeType: "inode/directory", size: 4096, isDir: true},
             {fileName: ".hidden.xml", baseName: ".hidden", extension: "xml", mimeType: "application/xml", size: 52, isDir: false},
-            {fileName: ".tarball.tar.bz2", baseName: ".tarball", extension: "tar.bz2", mimeType: "application/x-bzip-compressed-tar", size: 109, isDir: false},
+            {fileName: ".tarball.tar.bz2", baseName: ".tarball", extension: "tar.bz2", mimeType: "application/x-bzip2-compressed-tar", size: 109, isDir: false},
             {fileName: ".hidden", baseName: ".hidden", extension: "", mimeType: "text/plain", size: 6, isDir: false}
         ]
 


### PR DESCRIPTION
Shared-mime-info update changed the mime type string a bit. Updating to new form.

Changed by:

commit 382e7418fd0cef578add99ee5f59a8cc057f7b40
Author: Ingo Brückl <ib@wupperonline.de>
Date:   Thu Mar 9 17:54:38 2023 +0100

    Rename application/x-bzip to application/x-bzip2

    Also rename application/x-bzip-compressed-tar to
    application/x-bzip2-compressed-tar.