### PR TITLE
[nemo-filemanager] Make FileModel::refresh() reattempt directory watching. JB#62550

### DIFF
--- a/src/plugin/filemodel.h
+++ b/src/plugin/filemodel.h
@@ -194,6 +194,7 @@ signals:
 
 private slots:
     void readDirectory();
+    void scheduleContentChange();
 
 public:
     enum Changed {

--- a/src/plugin/statfileinfo.cpp
+++ b/src/plugin/statfileinfo.cpp
@@ -34,14 +34,14 @@
 
 #include <QMimeDatabase>
 
-StatFileInfo::StatFileInfo() :
-    m_selected(false)
+StatFileInfo::StatFileInfo()
+    : m_selected(false)
 {
     refresh();
 }
 
-StatFileInfo::StatFileInfo(QString fileName) :
-    m_fileName(fileName), m_selected(false)
+StatFileInfo::StatFileInfo(QString fileName)
+    : m_fileName(fileName), m_selected(false)
 {
     refresh();
 }


### PR DESCRIPTION
If on instantiation the path doesn't exist, the FileModel never got tracking enabled.

Making here at least explicit refresh() calls to reattempt that.